### PR TITLE
Create a new x-require element to require node.js scripts from inside HTML pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "btoa": "^1.1.2",
     "electron-compile-cache": "^0.6.2",
-    "electron-compilers": "^0.7.2",
+    "electron-compilers": "^0.8.0",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "yargs": "^3.8.0"

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,10 @@ import forAllFiles from './for-all-files';
 
 import ReadOnlyCompiler from './read-only-compiler';
 
+// We don't actually care about the x-require constructor, we just want to 
+// register the element
+require('./x-require');
+
 // NB: We intentionally delay-load this so that in production, you can create
 // cache-only versions of these compilers
 let allCompilerClasses = null;

--- a/src/x-require.js
+++ b/src/x-require.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+import url from 'url';
+
+export default (() => {
+  if (process.type !== 'renderer' || !window || !window.document) return null;
+  
+  let proto = _.extend(Object.create(HTMLElement.prototype), {
+    attributeChangedCallback: function(attrName, oldVal, newVal) {
+      if (attrName !== 'href') return;
+      let filePath = newVal;
+      
+      if (newVal.match(/^file:/i)) {
+        let theUrl = url.parse(newVal);
+        filePath = decodeURIComponent(theUrl.pathname);
+        if (process.platform === 'win32') {
+          filePath = filePath.slice(1);
+        }
+      }
+      
+      // Disallow require from reaching outside the application bundle
+      if (filePath.toLowerCase().indexOf(process.resourcesPath.toLowerCase()) < 0) {
+        throw new Error(`Cannot require ${filePath} outside of app bundle`);
+      }
+      
+      // NB: We don't do any path canonicalization here because we rely on
+      // InlineHtmlCompiler to have already converted any relative paths that
+      // were used with x-require into absolute paths.
+      require(filePath);
+    }
+  });
+
+  return document.registerElement('x-require', proto);
+}());

--- a/test/fixtures/x-require-valid.html
+++ b/test/fixtures/x-require-valid.html
@@ -1,0 +1,30 @@
+<dom-module id="loading-screen">
+  <style type="text/less">
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    
+    ul {
+      font-family: "MS Sans Serif";
+    }
+  }
+  </style>
+
+  <template>
+    <iron-pages id="selector" selected="{{_pageForScreen(screen)}}">
+      <div class="page">
+      </div>
+
+      <div class="page">
+      </div>
+
+      <div class="page">
+      </div>
+    </iron-pages>
+  </template>
+  
+  <x-require src='./valid'></x-require>
+</dom-module>

--- a/test/inline-html-compiler.js
+++ b/test/inline-html-compiler.js
@@ -1,7 +1,6 @@
 require('./support.js');
 
 import _ from 'lodash';
-import fs from 'fs';
 import path from 'path';
 import cheerio from 'cheerio';
 
@@ -13,10 +12,9 @@ const InlineHtmlCompiler = global.importCompilerByExtension('html');
 const validInputs = [
   'inline-valid.html',
   'inline-valid-2.html',
-]
+];
 
 describe('The inline HTML compiler', function() {
-  
   _.each(validInputs, (inputFile) => {
     it('should compile the valid fixture ' + inputFile, function() {
       let compilers = _.map([LessCompiler, BabelCompiler, CoffeescriptCompiler], (Klass) => {
@@ -43,7 +41,7 @@ describe('The inline HTML compiler', function() {
       
       let $ = cheerio.load(result);
       let tags = $('script');
-      expect(tags.length > 0).to.be.ok
+      expect(tags.length > 0).to.be.ok;
       
       $('script').map((__, el) => {
         let text = $(el).text();
@@ -52,5 +50,38 @@ describe('The inline HTML compiler', function() {
         expect(_.find(text.split('\n'), (l) => l.match(/sourceMappingURL/))).to.be.ok;
       });
     });
-  })
+  });
+  
+  it('should canonicalize x-require paths', function() {
+    let compilers = _.map([LessCompiler, BabelCompiler, CoffeescriptCompiler], (Klass) => {
+      let ret = new Klass();
+      ret.setCacheDirectory(null);
+      return ret;
+    });
+    
+    let fixture = new InlineHtmlCompiler((sourceCode, filePath) => {
+      let compiler = _.find(compilers, (x) => x.shouldCompileFile(filePath, sourceCode));
+      if (!compiler) {
+        throw new Error("Couldn't find a compiler for " + filePath);
+      }
+      
+      return compiler.loadFile(null, filePath, true, sourceCode);
+    });
+    
+    fixture.setCacheDirectory(null);
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'x-require-valid.html');
+    let result = fixture.loadFile(null, input, true);
+        
+    expect(result.length > 0).to.be.ok;
+    
+    let $ = cheerio.load(result);
+    let tags = $('x-require');
+    expect(tags.length === 1).to.be.ok;
+    
+    $('x-require').map((__, el) => {
+      let src = $(el).attr('src');
+      expect(_.find(src.split(/[\\\/]/), (x) => x === '.' || x === '..')).not.to.be.ok;
+    });
+  });
 });


### PR DESCRIPTION
This PR registers a new HTML Element, `x-require` - this element is similar to
a script tag with a 'src' attribute, but uses 'require' in order to load the
script. This PR also bumps the version of electron-compilers to fix up
relative paths in HTML Imports, which is the real advantage of x-require.