### PR TITLE
Road to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
   },
   "devDependencies": {
     "babel": "^5.8.21",
+    "babel-eslint": "^4.1.3",
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
     "chai-spies": "^0.7.0",
     "cheerio": "^0.19.0",
-    "electron-compilers": "^0.8.2",
+    "electron-compilers": "^1.0.0",
+    "eslint": "^1.5.1",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-compile",
-  "version": "0.9.2",
+  "version": "1.0.0",
   "description": "Electron supporting package to compile JS and CSS in Electron applications",
   "main": "lib/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "btoa": "^1.1.2",
     "electron-compile-cache": "^0.7.0",
-    "electron-compilers": "^0.8.2",
     "lodash": "^3.10.1",
     "mime-types": "^2.1.6",
     "mkdirp": "^0.5.1",
@@ -39,6 +38,7 @@
     "chai-as-promised": "^5.1.0",
     "chai-spies": "^0.7.0",
     "cheerio": "^0.19.0",
+    "electron-compilers": "^0.8.2",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.2"
   }

--- a/src/main.js
+++ b/src/main.js
@@ -33,8 +33,26 @@ let allCompilerClasses = null;
 //
 // Returns an {Array} of {CompileCache} objects.
 export function createAllCompilers(compilerOpts=null) {
-  allCompilerClasses = allCompilerClasses || require('electron-compilers');
-
+  if (!allCompilerClasses) {
+    // First we want to see if electron-compilers itself has been installed with
+    // devDependencies. If that's not the case, check to see if 
+    // electron-compilers is installed as a peer dependency (probably as a
+    // devDependency of the root project).
+    const locations = ['electron-compilers', '../../electron-compilers'];
+    
+    for (let location of locations) {
+      try {
+        allCompilerClasses = require(location);
+      } catch (e) { 
+        // Yolo
+      }
+    }
+    
+    if (!allCompilerClasses) {
+      throw new Error("Electron compilers not found but were requested to be loaded");
+    }
+  }
+  
   let HtmlCompiler = null;
   let ret = _.map(allCompilerClasses, (Klass) => {
     let exts = Klass.getExtensions();

--- a/test/css-compilers.js
+++ b/test/css-compilers.js
@@ -3,9 +3,7 @@ require('./support.js');
 import path from 'path';
 
 const toTest = [
-  { klass: global.importCompilerByExtension('less'), extension: 'less' },
-  { klass: global.importCompilerByExtension('scss'), extension: 'scss' },
-  { klass: global.importCompilerByExtension('scss'), extension: 'sass' },
+  { klass: global.importCompilerByExtension('less'), extension: 'less' }
 ];
 
 for (let compiler of toTest) {

--- a/test/fixtures/roboto.html
+++ b/test/fixtures/roboto.html
@@ -1,0 +1,10 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic,500,500italic,700,700italic">


### PR DESCRIPTION
This PR fixes a few things that require a version bump:

### BREAKING CHANGE: npm 3.0 and electron-compilers

npm 3.0's auto-dedupe throws a wrench in the npm 2.0 strategy of reaching into the modules and `rm -rf electron-compile/node_modules/electron-compilers` pre-production. What do we do?

Instead the new strategy is:

1. Add `electron-compile` as a `dependency` in your project
1. Add `electron-compilers` as a `devDependency` in your project

When you're making a build of your app, set `NODE_ENV` to `production`, and all of `electron-compilers` will be stripped out.

### BREAKING CHANGE: node-sass is no longer supported

node-sass breaks both Windows and Linux with Electron (the latter broken even if you don't even _use_ node-sass), so we're removing it, sorry. 

### Protocol-relative URLs are now fixed up, even on Chrome 44

This feature was removed in the Chrome 44+ Protocol Hook, but now it's back except for in CSS `@import` directives