### PR TITLE
cleanup lib and test-dist before recompiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Electron supporting package to compile JS and CSS in Electron applications",
   "main": "lib/main.js",
   "scripts": {
-    "compile": "babel --stage 1 -d lib/ src/ && babel --stage 1 --ignore 'test/fixtures/*' -d test-dist/ test/",
+    "compile": "git clean -xdf lib && git clean -xdf test-dist && babel --stage 1 -d lib/ src/ && babel --stage 1 --ignore 'test/fixtures/*' -d test-dist/ test/",
     "prepublish": "npm run compile",
     "test": "npm run compile && mocha test-dist/*"
   },


### PR DESCRIPTION
This actually surfaced in electron-compilers, but I'm pr-ing the fix into all 3 associated repos. Basically, use git to clean out the lib folder (and in this case, the test-dist folder) whenever a compile runs (including prepublish) to prevent accidentally publishing compiled files who's source has been removed.