### PR TITLE
simplify `pify` call

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^3.10.1",
     "mime-types": "^2.1.6",
     "mkdirp": "^0.5.1",
-    "pify": "^2.2.0",
+    "pify": "^2.3.0",
     "yargs": "^3.18.0"
   },
   "devDependencies": {

--- a/src/protocol-hook-44.js
+++ b/src/protocol-hook-44.js
@@ -8,7 +8,7 @@ import pify from 'pify';
 require('./regenerator');
 
 const magicWords = "__magic__file__to__help__electron__compile.js";
-const fsp = pify.all(require('fs'));
+const fsp = pify(require('fs'));
 
 let protocol = null;
 


### PR DESCRIPTION
The `.all()` method is just an alias for the main method now, so no point in using it.