### PR TITLE
Save all of CompilerHost's info under one file

### DIFF
--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -21,7 +21,7 @@ export default class CompileCache {
       if (newCachePath) return newCachePath;
 
       const digestObj = {
-        name: Object.getPrototypeOf(compiler).constructor.name,
+        name: compiler.name || Object.getPrototypeOf(compiler).constructor.name,
         version: compiler.getCompilerVersion(),
         options: compiler.compilerOptions
       };

--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -44,7 +44,7 @@ export default class CompilerHost {
     let fileChangeCache = FileChangedCache.loadFromData(info.fileChangeCache);
     let compilers = _.reduce(Object.keys(info.compilers), (acc, x) => {
       let cur = info.compilers[x];
-      acc[x] = new ReadOnlyCompiler(cur.compilerVersion, cur.compilerOptions, cur.inputMimeTypes);
+      acc[x] = new ReadOnlyCompiler(cur.name, cur.compilerVersion, cur.compilerOptions, cur.inputMimeTypes);
       
       return acc;
     }, {});
@@ -58,6 +58,7 @@ export default class CompilerHost {
       let Klass = Object.getPrototypeOf(compiler).constructor;
       
       let val = {
+        name: Klass.name,
         inputMimeTypes: Klass.getInputMimeTypes(),
         compilerOptions: compiler.compilerOptions,
         compilerVersion: compiler.getCompilerVersion()

--- a/src/read-only-compiler.js
+++ b/src/read-only-compiler.js
@@ -1,30 +1,25 @@
-import CompileCache from 'electron-compile-cache';
+import _ from 'lodash';
 
-export default class ReadOnlyCompiler extends CompileCache {
-  constructor(compilerInformation, mimeType) {
-    super();
-    
-    this.compilerInformation = compilerInformation;
-    this.mimeType = mimeType;
+export default class ReadOnlyCompiler {
+  constructor(compilerVersion, compilerOptions, inputMimeTypes) {
+    _.assign(this, { compilerVersion, compilerOptions, inputMimeTypes });
+  }
+  
+  async shouldCompileFile() { return true; }
+  async determineDependentFiles() { return []; }
+
+  async compile() {
+    throw new Error("Read-only compilers can't compile");
   }
 
-  getCompilerInformation() {
-    return this.compilerInformation;
+  shouldCompileFileSync() { return true; }
+  determineDependentFilesSync() { return []; }
+
+  compileSync() {
+    throw new Error("Read-only compilers can't compile");
   }
 
-  compile(sourceCode, filePath, cachePath) {
-    throw new Error(`Asked to compile ${filePath} in production!`);
-  }
-
-  getMimeType() {
-    return this.mimeType;
-  }
-
-  initializeCompiler() {
-    return this.compilerInformation.version;
-  }
-
-  static getExtensions() {
-    return [];
+  getCompilerVersion() {
+    return this.compilerVersion;
   }
 }

--- a/src/read-only-compiler.js
+++ b/src/read-only-compiler.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
 export default class ReadOnlyCompiler {
-  constructor(compilerVersion, compilerOptions, inputMimeTypes) {
-    _.assign(this, { compilerVersion, compilerOptions, inputMimeTypes });
+  constructor(name, compilerVersion, compilerOptions, inputMimeTypes) {
+    _.assign(this, { name, compilerVersion, compilerOptions, inputMimeTypes });
   }
   
   async shouldCompileFile() { return true; }

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -113,7 +113,7 @@ describe('The compiler host', function() {
     });
   });
   
-  it.only('Should read files from serialized compiler information', async function() {
+  it('Should read files from serialized compiler information', async function() {
     let input = path.join(__dirname, '..', 'test', 'fixtures');
 
     d("Attempting to run initial compile");

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -143,4 +143,35 @@ describe('The compiler host', function() {
       return true;
     });
   });
+  
+  it('Should read files from serialized compiler information synchronously', function() {
+    let input = path.join(__dirname, '..', 'test', 'fixtures');
+
+    d("Attempting to run initial compile");
+    this.fixture.compileAllSync(input, (filePath) => {
+      if (filePath.match(/invalid/)) return false;
+      if (filePath.match(/binaryfile/)) return false;
+      if (filePath.match(/minified/)) return false;
+      if (filePath.match(/source_map/)) return false;
+      
+      return true;
+    });
+    
+    d("Saving configuration");
+    this.fixture.saveConfigurationSync();
+    
+    d("Recreating from said configuration");
+    this.fixture = CompilerHost.createReadonlyFromConfigurationSync(this.tempCacheDir);
+    this.fixture.compileUncached = () => Promise.reject(new Error("Fail!"));
+
+    d("Recompiling everything from cached data");
+    this.fixture.compileAllSync(input, (filePath) => {
+      if (filePath.match(/invalid/)) return false;
+      if (filePath.match(/binaryfile/)) return false;
+      if (filePath.match(/minified/)) return false;
+      if (filePath.match(/source_map/)) return false;
+      
+      return true;
+    });
+  });
 });


### PR DESCRIPTION
This PR saves all of the information we need to run the cache into a single file and lets us recreate it

/cc #31