### PR TITLE
Parse configuration files

### DIFF
--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -157,6 +157,7 @@ export default class CompilerHost {
 
     let dependentFiles = await compiler.determineDependentFiles(code, filePath, ctx);
 
+    d(`Using compiler options: ${JSON.stringify(compiler.compilerOptions)}`);
     let result = await compiler.compile(code, filePath, ctx);
 
     let shouldInlineHtmlify = 

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -19,7 +19,7 @@ export function createCompilerHostFromConfiguration(info) {
   let rootCacheDir = info.rootCacheDir || calculateDefaultCompileCacheDirectory();
   
   let fileChangeCache = new FileChangedCache(info.appRoot);
-  let ret = CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
+  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
   
   _.each(Object.keys(info.options || {}), (x) => {
     let opts = info.options[x];

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -6,6 +6,10 @@ import pify from 'pify';
 const pfs = pify(fs);
 const d = require('debug')('electron-compile:config-parser');
 
+// NB: We intentionally delay-load this so that in production, you can create
+// cache-only versions of these compilers
+let allCompilerClasses = null;
+
 export async function createCompilerHostFromConfiguration(info) {
 }
 
@@ -16,4 +20,48 @@ export function createCompilerHostFromConfigFile(file) {
 }
 
 export function createCompilerHostFromProjectRoot(rootDir) {
+}
+
+// Public: Allows you to create new instances of all compilers that are
+// supported by electron-compile and use them directly. Currently supports
+// Babel, CoffeeScript, TypeScript, LESS, and Sass/SCSS.
+//
+// Returns an {Object} whose Keys are MIME types, and whose values are objects
+// which conform to {CompilerBase}.
+export function createCompilers() {
+  if (!allCompilerClasses) {
+    // First we want to see if electron-compilers itself has been installed with
+    // devDependencies. If that's not the case, check to see if
+    // electron-compilers is installed as a peer dependency (probably as a
+    // devDependency of the root project).
+    const locations = ['electron-compilers', '../../electron-compilers'];
+
+    for (let location of locations) {
+      try {
+        allCompilerClasses = require(location);
+      } catch (e) {
+        // Yolo
+      }
+    }
+
+    if (!allCompilerClasses) {
+      throw new Error("Electron compilers not found but were requested to be loaded");
+    }
+  }
+
+  let ret = {};
+  let instantiatedClasses = _.map(allCompilerClasses, (Klass) => {
+    if ('createFromCompilers' in Klass) {
+      return Klass.createFromCompilers(ret);
+    } else {
+      return new Klass();
+    }
+  });
+
+  return _.reduce(instantiatedClasses, (acc,x) => {
+    let Klass = Object.getPrototypeOf(x).constructor;
+
+    for (let type of Klass.getInputMimeTypes()) { acc[type] = x; }
+    return acc;
+  }, {});
 }

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -1,0 +1,19 @@
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import pify from 'pify';
+
+const pfs = pify(fs);
+const d = require('debug')('electron-compile:config-parser');
+
+export async function createCompilerHostFromConfiguration(info) {
+}
+
+export function createCompilerHostFromBabelRc(file) {
+}
+
+export function createCompilerHostFromConfigFile(file) {
+}
+
+export function createCompilerHostFromProjectRoot(rootDir) {
+}

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -92,6 +92,63 @@ export async function createCompilerHostFromProjectRoot(rootDir) {
   return createCompilerHostFromBabelRc(path.join(rootDir, 'project.json'));
 }
 
+export function createCompilerHostFromBabelRcSync(file) {
+  let info = JSON.parse(fs.readFileSync(file, 'utf8'));
+  
+  // project.json
+  if ('babel' in info) {
+    info = info.babel;
+  }
+  
+  if ('env' in info) {
+    let ourEnv = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+    info = info.env[ourEnv];
+  }
+  
+  // Are we still project.json (i.e. is there no babel info whatsoever?)
+  if ('name' in info && 'version' in info) {
+    return createCompilerHostFromConfiguration({
+      appRoot: path.dirname(file),
+      options: getDefaultConfiguration()
+    });
+  }
+  
+  return createCompilerHostFromConfiguration({
+    appRoot: path.dirname(file),
+    options: {
+      'text/javascript': info
+    }
+  });
+}
+
+export function createCompilerHostFromConfigFileSync(file) {
+  let info = JSON.parse(fs.readFileSync(file, 'utf8'));
+  
+  if ('env' in info) {
+    let ourEnv = process.env.ELECTRON_COMPILE_ENV || process.env.NODE_ENV || 'development';
+    info = info.env[ourEnv];
+  }
+  
+  return createCompilerHostFromConfiguration({
+    appRoot: path.dirname(file),
+    options: info
+  });
+}
+
+export function createCompilerHostFromProjectRootSync(rootDir) {
+  let compilerc = path.join(rootDir, '.compilerc');
+  if (fs.existsSync(compilerc)) {
+    return createCompilerHostFromConfigFile(compilerc);
+  }
+  
+  let babelrc = path.join(rootDir, '.babelrc');
+  if (fs.existsSync(compilerc)) {
+    return createCompilerHostFromBabelRc(babelrc);
+  }
+    
+  return createCompilerHostFromBabelRc(path.join(rootDir, 'project.json'));
+}
+
 export function calculateDefaultCompileCacheDirectory() {
   let tmpDir = process.env.TEMP || process.env.TMPDIR || '/tmp';
   let hash = require('crypto').createHash('md5').update(process.execPath).digest('hex');

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -31,11 +31,12 @@ export function createCompilerHostFromConfiguration(info) {
     compilers[x].compilerOptions = opts;
   });
   
+  d(`Created compiler host with options: ${JSON.stringify(info)}`);
   return ret;
 }
 
 export async function createCompilerHostFromBabelRc(file) {
-  let info = JSON.parse(await fs.readFile(file, 'utf8'));
+  let info = JSON.parse(await pfs.readFile(file, 'utf8'));
   
   // project.json
   if ('babel' in info) {
@@ -64,7 +65,7 @@ export async function createCompilerHostFromBabelRc(file) {
 }
 
 export async function createCompilerHostFromConfigFile(file) {
-  let info = JSON.parse(await fs.readFile(file, 'utf8'));
+  let info = JSON.parse(await pfs.readFile(file, 'utf8'));
   
   if ('env' in info) {
     let ourEnv = process.env.ELECTRON_COMPILE_ENV || process.env.NODE_ENV || 'development';
@@ -97,6 +98,9 @@ export function calculateDefaultCompileCacheDirectory() {
 
   let cacheDir = path.join(tmpDir, `compileCache_${hash}`);
   mkdirp.sync(cacheDir);
+  
+  d(`Using default cache directory: ${cacheDir}`);
+  return cacheDir;
 }
 
 export function getDefaultConfiguration() {

--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -67,7 +67,7 @@ export default class FileChangedCache {
     };
     
     this.changeCache[cacheKey] = { ctime, size, info };
-    d(`Cache entry for ${cacheKey}: ${this.changeCache[cacheKey]}`);
+    d(`Cache entry for ${cacheKey}: ${JSON.stringify(this.changeCache[cacheKey])}`);
 
     if (binaryData) {
       return _.extend({binaryData}, info);

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -8,7 +8,7 @@ import mkdirp from 'mkdirp';
 import FileChangeCache from '../lib/file-change-cache';
 import CompilerHost from '../lib/compiler-host';
 
-const d = require('debug')('electron-test:compiler-host');
+const d = require('debug')('test:compiler-host');
 
 let testCount=0;
 

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -2,6 +2,7 @@ import './support.js';
 
 import _ from 'lodash';
 import path from 'path';
+import fs from 'fs';
 import rimraf from 'rimraf';
 import mkdirp from 'mkdirp';
 import FileChangeCache from '../lib/file-change-cache';
@@ -36,7 +37,18 @@ describe('The compiler host', function() {
   afterEach(function() {
     rimraf.sync(this.tempCacheDir);
   });
-  
+
+  it('should compile basic HTML and not blow up', function() {
+    let input = '<html><style type="text/less">body { font-family: "lol"; }</style></html>';
+    let inFile = path.join(this.tempCacheDir, 'input.html');
+    fs.writeFileSync(inFile, input);
+    
+    let result = this.fixture.compileSync(inFile);
+
+    expect(result.mimeType).to.equal('text/html');
+    expect(result.code.length > input.length).to.be.ok;
+  });
+
   it('Should compile everything in the fixtures directory', async function() {
     let input = path.join(__dirname, '..', 'test', 'fixtures');
 

--- a/test/config-parser.js
+++ b/test/config-parser.js
@@ -1,0 +1,17 @@
+import {createCompilers} from '../lib/config-parser'
+
+describe('the configuration parser module', function() {
+  describe('the createCompilers method', function() {
+    it('should return compilers', function() {
+      let result = createCompilers();
+      expect(Object.keys(result).length > 0).to.be.ok;
+    });
+
+    it('should definitely have these compilers', function() {
+      let result = createCompilers();
+
+      expect(result['application/javascript']).to.be.ok;
+      expect(result['text/less']).to.be.ok;
+    });
+  });
+});

--- a/test/config-parser.js
+++ b/test/config-parser.js
@@ -1,4 +1,4 @@
-import {createCompilers} from '../lib/config-parser'
+import {createCompilers} from '../lib/config-parser';
 
 describe('the configuration parser module', function() {
   describe('the createCompilers method', function() {

--- a/test/config-parser.js
+++ b/test/config-parser.js
@@ -1,7 +1,5 @@
 import _ from 'lodash';
-import fs from 'fs';
 import path from 'path';
-import pify from 'pify';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 
@@ -13,7 +11,6 @@ import {
 } from '../lib/config-parser';
 
 const d = require('debug')('test:config-parser');
-const pfs = pify(fs);
 
 let testCount = 0;
 

--- a/test/config-parser.js
+++ b/test/config-parser.js
@@ -1,4 +1,16 @@
-import {createCompilers} from '../lib/config-parser';
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import pify from 'pify';
+import mkdirp from 'mkdirp';
+import rimraf from 'rimraf';
+
+import {createCompilers, createCompilerHostFromConfiguration} from '../lib/config-parser';
+
+const d = require('debug')('test:config-parser');
+const pfs = pify(fs);
+
+let testCount = 0;
 
 describe('the configuration parser module', function() {
   describe('the createCompilers method', function() {
@@ -12,6 +24,41 @@ describe('the configuration parser module', function() {
 
       expect(result['application/javascript']).to.be.ok;
       expect(result['text/less']).to.be.ok;
+    });
+  });
+  
+  describe('the createCompilerHostFromConfiguration method', function() {
+    beforeEach(function() {
+      this.tempCacheDir = path.join(__dirname, `__create_compiler_host_${testCount++}`);
+      mkdirp.sync(this.tempCacheDir);
+    });
+    
+    afterEach(function() {
+      rimraf.sync(this.tempCacheDir);
+    });
+      
+    it.only('respects suppressing source maps (scenario test)', async function() {
+      let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
+      
+      let result = createCompilerHostFromConfiguration({
+        appRoot: fixtureDir,
+        rootCacheDir: this.tempCacheDir,
+        options: {
+          'text/javascript': {
+            "presets": ["stage-0", "es2015"],
+            "sourceMaps": false
+          }
+        }
+      });
+      
+      let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
+      d(JSON.stringify(compileInfo));
+      
+      expect(compileInfo.mimeType).to.equal('text/javascript');
+      
+      let lines = compileInfo.code.split('\n');
+      expect(lines.length > 5).to.be.ok;
+      expect(_.any(lines, (x) => x.match(/sourceMappingURL=/))).not.to.be.ok;
     });
   });
 });

--- a/test/fixtures/babelrc-noenv
+++ b/test/fixtures/babelrc-noenv
@@ -1,0 +1,4 @@
+{
+  "presets": ["stage-0", "es2015", "react"],
+  "sourceMaps": "inline"
+}

--- a/test/fixtures/babelrc-production
+++ b/test/fixtures/babelrc-production
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "production": {
+      "presets": ["stage-0", "es2015", "react"],
+      "sourceMaps": false
+    },
+    "development": {
+      "presets": ["stage-0", "es2015", "react"],
+      "sourceMaps": "inline"
+    }
+  }
+}

--- a/test/fixtures/compilerc-noenv
+++ b/test/fixtures/compilerc-noenv
@@ -1,0 +1,6 @@
+{
+  "text/javascript": {
+    "presets": ["stage-0", "es2015", "react"],
+    "sourceMaps": "inline"
+  }
+}

--- a/test/fixtures/compilerc-production
+++ b/test/fixtures/compilerc-production
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "production": {
+      "text/javascript": {
+        "presets": ["stage-0", "es2015", "react"],
+        "sourceMaps": false
+      }
+    },
+    "development": {
+      "text/javascript": {
+        "presets": ["stage-0", "es2015", "react"],
+        "sourceMaps": "inline"
+      }
+    }
+  }
+}

--- a/test/main.js
+++ b/test/main.js
@@ -149,30 +149,3 @@ describe('exports for this library', function() {
     });
   });
 });
-
-describe('scenario tests', function() {
-  it('should be able to create a cache, then use it to resolve files solely with read-only-compiler', function() {
-    let sourceDir = path.join(__dirname, '..', 'src');
-    let targetDir = path.join(__dirname, 'readOnlyCompilerTest');
-    
-    try {
-      let realCompilers = createAllCompilers();
-      _.each(realCompilers, (x) => x.setCacheDirectory(targetDir));
-      
-      compileAll(sourceDir, realCompilers);
-      let compilerInfo = collectCompilerInformation(realCompilers);
-      
-      let fakeCompilers = _.map(
-        Object.keys(compilerInfo), 
-        (x) => new ReadOnlyCompiler(compilerInfo[x].options, compilerInfo[x].mimeType));
-        
-      // NB: Since 100% of these files are already in cache, they'll all be hits,
-      // compileAll will just pass them all. If ReadOnlyCompiler finds a file it
-      // doesn't know, it'll throw
-      _.each(fakeCompilers, (x) => x.setCacheDirectory(targetDir));
-      compileAll(sourceDir, fakeCompilers);
-    } finally {
-      rimraf.sync(targetDir);
-    }
-  });
-})

--- a/test/main.js
+++ b/test/main.js
@@ -8,31 +8,6 @@ import {forAllFiles} from '../lib/for-all-files';
 import {createCompilers} from '../lib/main-ng';
 
 describe('exports for this library', function() {
-  describe('the createCompilers method', function() {
-    it('should return compilers', function() {
-      let result = createCompilers();
-      expect(Object.keys(result).length > 0).to.be.ok;
-    });
-
-    it('should definitely have these compilers', function() {
-      let result = createCompilers();
-
-      expect(result['application/javascript']).to.be.ok;
-      expect(result['text/less']).to.be.ok;
-    });
-
-    it('should compile basic HTML and not blow up', function() {
-      let fixture = createCompilers();
-      let compiler = fixture['text/html'];
-
-      let input = '<html><style type="text/less">body { font-family: "lol"; }</style></html>';
-      let result = compiler.compileSync(input, 'foo.html', {});
-
-      expect(result.mimeType).to.equal('text/html');
-      expect(result.code.length > input.length).to.be.ok;
-    });
-  });
-
   return;
   
   const {compile, compileAll, createAllCompilers, collectCompilerInformation} = require('../lib/main');


### PR DESCRIPTION
This PR sets up methods to initialize a CompilerHost based on either a `.babelrc` file, or an electron-compile `.compilerc` which is similar to babelrc except instead of a list of options, it’s a list of MIME types and the options to set.

#### Without an environment:

```js
{
  "text/javascript": {
    "presets": ["stage-0", "es2015", "react"],
    "sourceMaps": "inline"
  }
}
```

#### With environments:

```js
{
  "env": {
    "production": {
      "text/javascript": {
        "presets": ["stage-0", "es2015", "react"],
        "sourceMaps": false
      }
    },
    "development": {
      "text/javascript": {
        "presets": ["stage-0", "es2015", "react"],
        "sourceMaps": "inline"
      }
    }
  }
}
```

/cc #31