### PR TITLE
Fix path issues on Windows

### DIFF
--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -3,6 +3,7 @@ import zlib from 'zlib';
 import crypto from 'crypto';
 import {pfs, pzlib} from './promise';
 import _ from 'lodash';
+import sanitizeFilePath from './sanitize-paths';
 
 const d = require('debug')('electron-compile:file-change-cache');
 
@@ -19,7 +20,7 @@ const d = require('debug')('electron-compile:file-change-cache');
  */ 
 export default class FileChangedCache {
   constructor(appRoot, failOnCacheMiss=false) {
-    this.appRoot = appRoot;
+    this.appRoot = sanitizeFilePath(appRoot);
     this.failOnCacheMiss = failOnCacheMiss;
     this.changeCache = {};
   }
@@ -86,7 +87,7 @@ export default class FileChangedCache {
    *                                     was text and there was a cache miss
    */   
   async getHashForPath(absoluteFilePath) {
-    let cacheKey = absoluteFilePath;
+    let cacheKey = sanitizeFilePath(absoluteFilePath);
     if (this.appRoot) {
       cacheKey = absoluteFilePath.replace(this.appRoot, '');
     } 

--- a/src/sanitize-paths.js
+++ b/src/sanitize-paths.js
@@ -1,0 +1,11 @@
+/**
+ * Electron will sometimes hand us paths that don't match the platform if they
+ * were derived from a URL (i.e. 'C:/Users/Paul/...'), whereas the cache will have
+ * saved paths with backslashes.
+ *  
+ * @private
+ */ 
+export default function sanitizeFilePath(file) {
+  let ret = file.replace(/[\\\/]/g, '/');
+  return ret.toLowerCase();
+}

--- a/src/sanitize-paths.js
+++ b/src/sanitize-paths.js
@@ -1,3 +1,5 @@
+//const d = require('debug')('electron-compile:sanitize-paths');
+
 /**
  * Electron will sometimes hand us paths that don't match the platform if they
  * were derived from a URL (i.e. 'C:/Users/Paul/...'), whereas the cache will have
@@ -6,6 +8,9 @@
  * @private
  */ 
 export default function sanitizeFilePath(file) {
+  // d(file);
+  if (!file) return file;
+
   let ret = file.replace(/[\\\/]/g, '/');
   return ret.toLowerCase();
 }

--- a/test/file-change-cache.js
+++ b/test/file-change-cache.js
@@ -89,7 +89,7 @@ describe('The file changed cache', function() {
   });
 
   it("Throws on cache misses in production mode", function() {
-    this.fixture = new FileChangeCache(true);
+    this.fixture = new FileChangeCache(null, true);
 
     let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.js');
     expect(this.fixture.getHashForPath(input)).to.eventually.throw(Error);


### PR DESCRIPTION
When caches were run in production on Windows, C:/foo/bar/baz would end up sometimes getting passed in, but get compared to C:\foo\bar\baz, even though Windows would consider them equivalent.