### PR TITLE
Add mime-types for Sass/SCSS and CJSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-compile",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Electron supporting package to compile JS and CSS in Electron applications",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",

--- a/src/rig-mime-types.js
+++ b/src/rig-mime-types.js
@@ -3,15 +3,18 @@ import mimeTypes from 'mime-types';
 
 const typesToRig = {
   'text/typescript': 'ts',
-  'text/jade': 'jade'
+  'text/jade': 'jade',
+  'text/sass': 'sass',
+  'text/scss': 'scss',
+  'text/cjsx': 'cjsx'
 };
 
 
 /**
  * Adds MIME types for types not in the mime-types package
- *  
+ *
  * @private
- */ 
+ */
 export function init() {
   _.each(Object.keys(typesToRig), (type) => {
     let ext = typesToRig[type];


### PR DESCRIPTION
Part of the proposed pull request for [electron-compilers](https://github.com/electronjs/electron-compilers/pull/23) which adds support for these mime-types.