### PR TITLE
Remove original source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4.1"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mime-types": "^2.1.8",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
+    "temp": "^0.8.3",
     "yargs": "^3.31.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/paulcbetts/electron-compile",
   "main": "lib/index.js",
   "dependencies": {
+    "asar": "^0.9.1",
     "babel-polyfill": "^6.3.14",
     "btoa": "^1.1.2",
     "debug": "^2.2.0",

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -103,7 +103,7 @@ export function createCompilerHostFromConfiguration(info) {
   let rootCacheDir = info.rootCacheDir || calculateDefaultCompileCacheDirectory();
   
   d(`Creating CompilerHost: ${JSON.stringify(info)}, rootCacheDir = ${rootCacheDir}`);
-  let fileChangeCache = new FileChangedCache(info.appRoot);
+  let fileChangeCache = new FileChangedCache(path.resolve(info.appRoot));
   let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
   
   _.each(Object.keys(info.options || {}), (x) => {

--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -98,6 +98,9 @@ export default class FileChangedCache {
       cacheKey = cacheKey.replace(this.originalAppRoot, '');
     }
     
+    cacheKey = cacheKey.replace(/^\//, '');
+    
+    d(`Checking for cache entry: '${cacheKey}'`);
     let cacheEntry = this.changeCache[cacheKey];
     
     if (this.failOnCacheMiss) {
@@ -195,6 +198,9 @@ export default class FileChangedCache {
       cacheKey = cacheKey.replace(this.originalAppRoot, '');
     }
     
+    cacheKey = cacheKey.replace(/^\//, '');
+    
+    d(`Checking for cache entry: ${cacheKey}`);
     let cacheEntry = this.changeCache[cacheKey];
     
     if (this.failOnCacheMiss) {

--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -96,6 +96,9 @@ export default class FileChangedCache {
    */   
   async getHashForPath(absoluteFilePath) {
     let cacheKey = sanitizeFilePath(absoluteFilePath);
+    
+    cacheKey = cacheKey.replace('stub.asar', 'app.asar');
+    
     if (this.appRoot) {
       cacheKey = cacheKey.replace(this.appRoot, '');
     } 
@@ -235,6 +238,8 @@ export default class FileChangedCache {
   
   getHashForPathSync(absoluteFilePath) {
     let cacheKey = sanitizeFilePath(absoluteFilePath);
+    cacheKey = cacheKey.replace('stub.asar', 'app.asar');
+
     if (this.appRoot) {
       cacheKey = cacheKey.replace(this.appRoot, '');
     } 

--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 import {pfs, pzlib} from './promise';
 import _ from 'lodash';
 import sanitizeFilePath from './sanitize-paths';
+import {forAllEmptyDirs} from './for-all-files';
 
 // Lazy-require ASAR since most of the time we won't need it
 let asar = null;
@@ -221,6 +222,10 @@ export default class FileChangedCache {
       if (removeFiles) {
         await pfs.unlink(path.join(this.appRoot, key));
       }
+    }
+    
+    if (removeFiles) {
+      await forAllEmptyDirs(this.appRoot, async (filePath) => pfs.rmdir(filePath));
     }
     
     await new Promise((resolve) => {

--- a/src/promise.js
+++ b/src/promise.js
@@ -12,4 +12,4 @@ export const pfs = pify(require('fs'));
 /**
  * @private
  */ 
- export const pzlib = pify(require('zlib'));
+export const pzlib = pify(require('zlib'));

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import fs from 'fs';
+import {Module} from 'module';
 import path from 'path';
 import mimeTypes from 'mime-types';
 
@@ -14,9 +15,9 @@ import mimeTypes from 'mime-types';
 export default function registerRequireExtension(compilerHost) {
   let stubFile = path.join(compilerHost.rootCacheDir, '..', 'stub.asar');
   if (fs.existsSync(stubFile)) {
-    process.env.NODE_PATH = stubFile;
+    process.env.NODE_PATH = `${Module.globalPaths.join(':')}:${stubFile}`;
   } else {
-    process.env.NODE_PATH = '';
+    process.env.NODE_PATH = Module.globalPaths.join(':');
   }
   
   require('module').Module._initPaths();

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
 import mimeTypes from 'mime-types';
 
 /**
@@ -10,6 +12,15 @@ import mimeTypes from 'mime-types';
  * @param  {CompilerHost} compilerHost  The compiler host to use for compilation.
  */ 
 export default function registerRequireExtension(compilerHost) {
+  let stubFile = path.join(compilerHost.rootCacheDir, '..', 'stub.asar');
+  if (fs.existsSync(stubFile)) {
+    process.env.NODE_PATH = stubFile;
+  } else {
+    process.env.NODE_PATH = '';
+  }
+  
+  require('module').Module._initPaths();
+  
   _.each(Object.keys(compilerHost.compilersByMimeType), (mimeType) => {
     let ext = mimeTypes.extension(mimeType);
     

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -14,10 +14,12 @@ import mimeTypes from 'mime-types';
  */ 
 export default function registerRequireExtension(compilerHost) {
   let stubFile = path.join(compilerHost.rootCacheDir, '..', 'stub.asar');
+  
   if (fs.existsSync(stubFile)) {
     process.env.NODE_PATH = `${Module.globalPaths.join(':')}:${stubFile}`;
   } else {
     process.env.NODE_PATH = Module.globalPaths.join(':');
+    stubFile = null;
   }
   
   require('module').Module._initPaths();
@@ -26,7 +28,8 @@ export default function registerRequireExtension(compilerHost) {
     let ext = mimeTypes.extension(mimeType);
     
     require.extensions[`.${ext}`] = (module, filename) => {
-      let {code} = compilerHost.compileSync(filename);
+      let name = stubFile ? filename.replace('app.asar', 'stub.asar') : filename;
+      let {code} = compilerHost.compileSync(name);
       module._compile(code, filename);
     };
   });


### PR DESCRIPTION
This PR allows you to optionally remove the original source files, leaving only the .cache folder. 

Unfortunately, because node.js’s module system attempts to `realpath` the files before actually accessing them, we have to create a fake file tree using a stub ASAR archive, then add it to the global paths. This is kinda hacky, but not _that_ hacky.