### PR TITLE
Rig HTML files that come from node_modules folders

### DIFF
--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -147,6 +147,29 @@ export function initializeProtocolHook(compilerHost) {
 
     // NB: Special-case files coming from atom.asar or node_modules
     if (filePath.match(/[\/\\]atom.asar/) || filePath.match(/[\/\\]node_modules/)) {
+      // NBs on NBs: If we're loading an HTML file from node_modules, we still have
+      // to do the HTML document rigging
+      if (filePath.match(/\.html?$/i)) {
+        let riggedContents = null;
+        fs.readFile(filePath, 'utf8', (err, contents) => {
+          if (err) {
+            if (err.errno === 34) {
+              finish(-6); // net::ERR_FILE_NOT_FOUND
+              return;
+            } else {
+              finish(-2); // net::FAILED
+              return;
+            }
+          }
+
+          riggedContents = rigHtmlDocumentToInitializeElectronCompile(contents);
+          finish({ data: new Buffer(riggedContents), mimeType: 'text/html' });
+          return;
+        });
+
+        return;
+      }
+
       requestFileJob(filePath, finish);
       return;
     }


### PR DESCRIPTION
Even if HTML files come from a node_modules folder, we still need to rig
it so that we initialize electron-compile. For example, electron-mocha
will initialize a BrowserWindow with one of its own files