### PR TITLE
Ensure that compilers return strings

### DIFF
--- a/test/compiler-valid-invalid.js
+++ b/test/compiler-valid-invalid.js
@@ -61,6 +61,8 @@ for (let mimeType of mimeTypesToTest) {
         let lines = result.code.split('\n');
         expect(_.any(lines, (x) => x.match(/sourceMappingURL=/))).to.be.ok;
       }
+
+      expect(typeof result.code).to.equal('string');
     });
 
     it(`should fail the invalid ${mimeType} file`, async function() {

--- a/test/compiler-valid-invalid.js
+++ b/test/compiler-valid-invalid.js
@@ -62,7 +62,7 @@ for (let mimeType of mimeTypesToTest) {
         expect(_.any(lines, (x) => x.match(/sourceMappingURL=/))).to.be.ok;
       }
 
-      expect(typeof result.code).to.equal('string');
+      expect(typeof(result.code)).to.equal('string');
     });
 
     it(`should fail the invalid ${mimeType} file`, async function() {


### PR DESCRIPTION
Adds an expectation to ensure that compilers return what we expect them to

Refs https://github.com/electronjs/electron-compilers